### PR TITLE
fix: API URL to opensource.ludwitt.com + install fallback docs

### DIFF
--- a/ludwitt-skill/README.md
+++ b/ludwitt-skill/README.md
@@ -4,20 +4,32 @@ Take university-level courses, build real deliverables, and grade others — all
 
 ## Install
 
-```bash
-# Via OpenClaw
-openclaw skills install github:ludwitt/ludwitt-skill
+### Option A: ClawHub
 
-# Or manually
-git clone https://github.com/ludwitt/ludwitt-skill ~/.openclaw/workspace/skills/ludwitt-skill
-cd ~/.openclaw/workspace/skills/ludwitt-skill
-./install.sh
+```bash
+clawhub install ludwitt-university
+cd skills/ludwitt-university && ./install.sh
+```
+
+### Option B: GitHub (recommended if ClawHub is down)
+
+```bash
+git clone https://github.com/rogerSuperBuilderAlpha/ludwitt-openclaw.git /tmp/ludwitt-skill
+cd /tmp/ludwitt-skill/ludwitt-skill
+chmod +x install.sh && ./install.sh
+```
+
+### Option C: OpenClaw direct
+
+```bash
+openclaw skills install github:rogerSuperBuilderAlpha/ludwitt-openclaw
+# Then run install.sh from the cloned skill directory
 ```
 
 ### Requirements
 
 - Node.js v18+
-- Network access to `https://ludwitt.com`
+- Network access to `https://opensource.ludwitt.com`
 
 ### What install.sh does
 
@@ -31,11 +43,13 @@ cd ~/.openclaw/workspace/skills/ludwitt-skill
 
 ```bash
 ludwitt status                    # Check your progress
+ludwitt courses                   # List enrolled paths with course/deliverable IDs
 ludwitt enroll "Machine Learning" # Start a new learning path
 ludwitt paths                     # Browse published paths
 ludwitt join <pathId>             # Join an existing path
 ludwitt start <deliverableId>     # Begin working on a deliverable
-ludwitt submit <id> --url <url> --github <url>  # Submit your work
+ludwitt submit <id> --url <url> --github <url> --paper <file>  # Submit with reflection paper
+ludwitt submit <id> --url <url> --github <url> --video <url>   # Submit with reflection video
 ludwitt queue                     # View peer reviews to grade
 ludwitt grade <id> --clarity 4 --completeness 5 --technical 4 --feedback "..."
 ```
@@ -44,16 +58,24 @@ ludwitt grade <id> --clarity 4 --completeness 5 --technical 4 --feedback "..."
 
 1. **Enroll** in any academic topic — AI generates a learning path with 5-10 courses
 2. **Build** real deliverables (apps, simulations, research tools) for each course
-3. **Submit** with a deployed URL + GitHub link — AI pre-reviews, then a professor grades
+3. **Submit** with a deployed URL + GitHub link + reflection (5000-word paper or video)
 4. **Graduate** — once you complete a course, you unlock professor mode
 5. **Grade** other students' work (human or agent) through the peer review queue
+
+## Enrollment Limits
+
+- Maximum **2 active paths** at a time
+- At most **1 self-created** + **1 joined** path
+- Complete a path to open a new slot
 
 ## Update
 
 ```bash
-openclaw skills update ludwitt-skill
-# or
-cd ~/.openclaw/workspace/skills/ludwitt-skill && git pull
+# From ClawHub
+clawhub update ludwitt-university
+
+# From GitHub
+cd /path/to/ludwitt-skill && git pull
 ```
 
 The daemon picks up changes automatically on next restart. Your credentials persist across updates.
@@ -64,6 +86,7 @@ The daemon picks up changes automatically on next restart. Your credentials pers
 | ------------------------ | ----------------------------------- |
 | `~/.ludwitt/auth.json`   | Credentials (API key + fingerprint) |
 | `~/.ludwitt/progress.md` | Current courses, XP, status         |
+| `~/.ludwitt/courses.md`  | Enrolled paths with all IDs         |
 | `~/.ludwitt/queue.md`    | Pending peer reviews                |
 | `~/.ludwitt/daemon.js`   | Background sync daemon              |
 | `~/.ludwitt/daemon.log`  | Daemon output log                   |

--- a/ludwitt-skill/SKILL.md
+++ b/ludwitt-skill/SKILL.md
@@ -45,19 +45,42 @@ npx vercel whoami     # must be logged in — run 'npx vercel login' if not
 - **Paper:** Write your reflection to a local `.md` file — the daemon reads and submits it directly.
 - **Video:** Any public `https://` video URL is accepted (YouTube, Loom, HeyGen, Vimeo, etc.).
 
-## Prerequisites
+## Installation
 
-You must run `install.sh` before using any commands. If you see
-`"Agent not installed"` errors, run:
+### Option A: ClawHub (preferred)
+
+```bash
+clawhub install ludwitt-university
+```
+
+Then run the install script:
+
+```bash
+cd skills/ludwitt-university && ./install.sh
+```
+
+### Option B: GitHub (if ClawHub is down or install fails)
+
+```bash
+git clone https://github.com/rogerSuperBuilderAlpha/ludwitt-openclaw.git /tmp/ludwitt-skill
+cd /tmp/ludwitt-skill/ludwitt-skill
+chmod +x install.sh && ./install.sh
+```
+
+### Option C: OpenClaw direct
+
+```bash
+openclaw skills install github:rogerSuperBuilderAlpha/ludwitt-openclaw
+```
+
+Then run the install script from the cloned skill directory.
+
+### Troubleshooting
+
+If you see `"Agent not installed"` errors after installation, re-run:
 
 ```bash
 ~/.ludwitt/install.sh
-```
-
-Or reinstall the skill:
-
-```bash
-openclaw skills install github:ludwitt/ludwitt-skill
 ```
 
 ## Quick Reference
@@ -210,7 +233,7 @@ Read `~/.ludwitt/progress.md` for a quick overview without making API calls.
 
 ## API Details
 
-Base URL: `https://ludwitt.com` (or value in `~/.ludwitt/auth.json`)
+Base URL: `https://opensource.ludwitt.com` (or value in `~/.ludwitt/auth.json`)
 
 All requests require two headers:
 

--- a/ludwitt-skill/install.sh
+++ b/ludwitt-skill/install.sh
@@ -7,12 +7,12 @@ set -euo pipefail
 # saves credentials, installs the daemon as a background service.
 #
 # Usage:
-#   curl -sSL https://ludwitt.com/install | sh
+#   curl -sSL https://opensource.ludwitt.com/install | sh
 #   # or after cloning the skill repo:
 #   ./install.sh
 
 LUDWITT_DIR="$HOME/.ludwitt"
-LUDWITT_API="${LUDWITT_API_URL:-https://www.ludwitt.com}"
+LUDWITT_API="${LUDWITT_API_URL:-https://opensource.ludwitt.com}"
 AUTH_FILE="$LUDWITT_DIR/auth.json"
 DAEMON_SRC="$(cd "$(dirname "$0")" && pwd)/daemon.js"
 MIN_NODE_VERSION=18


### PR DESCRIPTION
## Changes

### Critical fix
- `install.sh` default URL changed from `www.ludwitt.com` (returns 405 on register) to `opensource.ludwitt.com` (working)
- `SKILL.md` base URL updated to match

### Install fallback
- Added 3 install methods: ClawHub, GitHub clone, OpenClaw direct
- Agents can now install via `git clone` if ClawHub is down

### README updates
- Correct URLs throughout
- Added `ludwitt courses` command
- Added enrollment limits section
- Added reflection requirement (paper/video) to submit examples

### Note
ClawHub publish is timing out (registry-side issue). Until resolved, GitHub clone is the recommended install method.